### PR TITLE
Better Support Serializer Instances

### DIFF
--- a/lib/ivy/serializers/serializer.rb
+++ b/lib/ivy/serializers/serializer.rb
@@ -3,24 +3,22 @@ require 'ivy/serializers/registry'
 module Ivy
   module Serializers
     class Serializer
-      class << self
-        attr_accessor :_registry
+      attr_reader :_registry
 
-        def inherited(base)
-          base._registry = Registry.new
-        end
+      def initialize
+        @_registry = Registry.new
+      end
 
-        def links(generator, resource)
-          _registry.links(generator, resource)
-        end
+      def links(generator, resource)
+        _registry.links(generator, resource)
+      end
 
-        def map(klass, &block)
-          _registry.map(klass, &block)
-        end
+      def map(klass, &block)
+        _registry.map(klass, &block)
+      end
 
-        def resource(generator, resource)
-          _registry.resource(generator, resource)
-        end
+      def resource(generator, resource)
+        _registry.resource(generator, resource)
       end
     end
   end


### PR DESCRIPTION
It seems as though better supporting a serializer that is an instance of a Class and not a Class itself is useful. I have a use case where I'm doing URL generation and need access to a view context or controller. Currently, I have to reimplement the `links`, `map`, and `resource` class methods as instance methods referring to the class calls.
